### PR TITLE
fix: Make sure onChange is called for invalid dates

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "HackerOne",
   "name": "@concur/react-datepicker",
   "description": "Fork of react-datepicker (https://github.com/Hacker0x01/react-datepicker)",
-  "version": "0.41.2",
+  "version": "0.41.3",
   "license": "MIT",
   "homepage": "https://github.com/Hacker0x01/react-datepicker",
   "main": "dist/react-datepicker.min.js",

--- a/src/datepicker.jsx
+++ b/src/datepicker.jsx
@@ -188,7 +188,7 @@ var DatePicker = React.createClass({
       return
     }
 
-    if (!isSameDay(this.props.selected, changedDate)) {
+    if (!isSameDay(this.props.selected, changedDate) || this.props.disableDateAutoCorrection) {
       if (changedDate !== null) {
         if (this.props.selected) {
           changedDate = moment(changedDate).set({


### PR DESCRIPTION
#### JIRA [CORUI-1429](https://jira.concur.com/jira/browse/CORUI-1429)
#### Description
Added check in `setSelected` for the `disableDateAutoCorrection` property to make sure `onChange` was getting called (albeit with a null value for invalid dates).